### PR TITLE
Add ability to use puppet/archive instead of remote_file

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -9,5 +9,8 @@ fixtures:
     remotefile:
       repo: 'https://github.com/lwf/puppet-remote_file.git'
       ref: 'v1.1.3'
+    archive:
+      repo: 'https://github.com/voxpupuli/puppet-archive.git'
+      ref: 'v3.1.0'
   symlinks:
     minio: "#{source_dir}"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -57,10 +57,29 @@ Style/TrailingCommaInArguments:
   Description: Prefer always trailing comma on multiline argument lists. This makes
     diffs, and re-ordering nicer.
   EnforcedStyleForMultiline: comma
-Style/TrailingCommaInLiteral:
-  Description: Prefer always trailing comma on multiline literals. This makes diffs,
-    and re-ordering nicer.
-  EnforcedStyleForMultiline: comma
+
+Style/TrailingCommaInArrayLiteral:
+  # If `comma`, the cop requires a comma after the last item in an array,
+  # but only when each item is on its own line.
+  # If `consistent_comma`, the cop requires a comma after the last item of all
+  # non-empty array literals.
+  EnforcedStyleForMultiline: no_comma
+  SupportedStylesForMultiline:
+    - comma
+    - consistent_comma
+    - no_comma
+
+Style/TrailingCommaInHashLiteral:
+  # If `comma`, the cop requires a comma after the last item in a hash,
+  # but only when each item is on its own line.
+  # If `consistent_comma`, the cop requires a comma after the last item of all
+  # non-empty hash literals.
+  EnforcedStyleForMultiline: no_comma
+  SupportedStylesForMultiline:
+    - comma
+    - consistent_comma
+    - no_comma
+
 Style/SymbolArray:
   Description: Using percent style obscures symbolic intent of array's contents.
   EnforcedStyle: brackets

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -28,3 +28,4 @@ minio::service_template: 'minio/systemd.erb'
 minio::service_path: '/lib/systemd/system/minio.service'
 minio::service_provider: 'systemd'
 minio::service_mode: '0644'
+minio::install_provider: remote_file

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -120,6 +120,7 @@ class minio (
   String $service_path,
   String $service_provider,
   String $service_mode,
+  Enum['remote_file', 'archive'] $install_provider,
   ) {
 
   class { '::minio::user': }

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -28,6 +28,7 @@ describe 'minio::install', type: :class do
             service_path: '/lib/systemd/system/minio.service',
             service_provider: 'systemd',
             service_mode: '0644',
+            provider: 'remote_file',
           }
         end
 
@@ -42,6 +43,47 @@ describe 'minio::install', type: :class do
         it { is_expected.to contain_exec('permissions:/opt/minio/minio') }
         it { is_expected.to contain_exec('permissions:/var/log/minio') }
         it { is_expected.to contain_exec('permissions:/var/minio') }
+      end
+      context 'with all defaults' do
+        let :params do
+          {
+            package_ensure: 'present',
+            base_url: 'https://dl.minio.io/server/minio/release',
+            version: 'RELEASE.2017-09-29T19-16-56Z',
+            checksum: 'b7707b11c64e04be87b4cf723cca5e776b7ed3737c0d6b16b8a3d72c8b183135',
+            checksum_type: 'sha256',
+            owner: 'minio',
+            group: 'minio',
+            configuration_directory: '/etc/minio',
+            installation_directory: '/opt/minio',
+            storage_root: '/var/minio',
+            log_directory: '/var/log/minio',
+            listen_ip: '127.0.0.1',
+            listen_port: 9000,
+            manage_service: true,
+            service_template: 'minio/systemd.erb',
+            service_path: '/lib/systemd/system/minio.service',
+            service_provider: 'systemd',
+            service_mode: '0644',
+            provider: 'archive',
+          }
+        end
+        it { is_expected.to_not contain_remote_file('minio') }
+        it {
+          is_expected.to contain_file('minio')
+        }
+        it {
+          case facts[:architecture]
+          when 'x86_64'
+            arch = 'amd64'
+          when 'x86'
+            arch = '386'
+          else
+            arch = facts[:architecture]
+          end
+          is_expected.to contain_archive("https://dl.minio.io/server/minio/release/linux-#{arch}/archive/minio.RELEASE.2017-09-29T19-16-56Z")
+            .that_subscribes_to('File[minio]')
+        }
       end
     end
   end


### PR DESCRIPTION
Subj.

Also, updated Rubocop rules. Copied from https://github.com/rubocop-hq/rubocop/blob/55ac1482e90f9ebbc974377f965745af79afbc6b/config/default.yml#L1458
