### PR TITLE
Prevent puppet from overwritting the configuration file

### DIFF
--- a/lib/facter/check_configuration_file.rb
+++ b/lib/facter/check_configuration_file.rb
@@ -1,0 +1,7 @@
+require 'facter'
+
+Facter.add(:check_configuration_file) do
+  setcode do
+    File.exist? '/etc/minio/config.json'
+  end
+end

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -79,11 +79,12 @@ class minio::config (
 
   $resulting_configuration = to_sorted_json(deep_merge($default_configuration, $configuration))
 
-  file { "${configuration_directory}/config.json":
-    content => $resulting_configuration,
-    owner   => $owner,
-    group   => $group,
-    mode    => '0644',
+  unless $facts['check_configuration_file'] {
+      file { "${configuration_directory}/config.json":
+        content => $resulting_configuration,
+        owner   => $owner,
+        group   => $group,
+        mode    => '0644',
+      }
   }
-
 }


### PR DESCRIPTION
Solution to the constant restart problem mentioned in #6 

If /etc/minio/config.json is present, don't overwrite it.
Stops the restarts every puppet run.
