### PR TITLE
Prevent puppet from overwritting the configuration file (configurable)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ class { 'minio':
     log_directory => '/var/log/minio',
     listen_ip => '127.0.0.1',
     listen_port => '9000',
+    replace_configuration => false,
     configuration => {
         'credential' => {
           'accessKey' => 'ADMIN',
@@ -121,6 +122,7 @@ class { 'minio::service':
 
 ```puppet
 class { 'minio::config':
+    replace_configuration => false,
     configuration => {
         'credential' => {
           'accessKey' => 'ADMIN',

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -14,6 +14,7 @@ minio::configuration_directory: '/etc/minio'
 minio::installation_directory: '/opt/minio'
 minio::storage_root: '/var/minio'
 minio::log_directory: '/var/log/minio'
+minio::replace_configuration: false
 minio::configuration:
   'version': '19'           # Depends on used Minio release
   'credential':

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -38,6 +38,7 @@
 # Copyright 2017 Daniel S. Reichenbach <https://kogitoapp.com>
 #
 class minio::config (
+  $replace_configuration   = $minio::replace_configuration,
   $configuration           = $minio::configuration,
   $owner                   = $minio::owner,
   $group                   = $minio::group,
@@ -84,6 +85,7 @@ class minio::config (
     owner   => $owner,
     group   => $group,
     mode    => '0644',
+    replace => $replace_configuration,
   }
 
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -57,6 +57,9 @@
 # * `listen_port`
 # Port on which Minio should listen to requests.
 #
+# * `replace_configuration`
+# Boolean indicating if the Minio configuration file should be updated even if it exists. Default: 'false'
+#
 # * `configuration`
 # Hash style settings for configuring Minio.
 #

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -116,6 +116,7 @@ class minio (
   String $listen_ip,
   Integer $listen_port,
 
+  Boolean $replace_configuration,
   Hash $configuration,
 
   Boolean $manage_service,

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
     "dependencies": [
         {
             "name": "puppetlabs-stdlib",
-            "version_requirement": ">= 4.14.0 < 6.0.0"
+            "version_requirement": ">= 4.14.0 < 7.0.0"
         },
         {
             "name": "lwf-remote_file",

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -10,6 +10,7 @@ describe 'minio::config', type: :class do
       context 'with all defaults' do
         let :params do
           {
+            replace_configuration: false,
             configuration: {
               'version' => '19',
               'credential' => {


### PR DESCRIPTION
Opt-out flag to prevent rewriting minio's config every puppet run, addresses #6

Also updates puppet dependencies to more reliably work with Puppet 6