### PR TITLE
Fix bug when setting ownership of config directory

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -136,7 +136,7 @@ class minio::install (
   }
 
   exec { "permissions:${configuration_directory}":
-    command     => "chown -Rf ${owner}:${group} ${installation_directory}",
+    command     => "chown -Rf ${owner}:${group} ${configuration_directory}",
     path        => '/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin',
     refreshonly => true,
   }


### PR DESCRIPTION
Due to a typo, the permissions setting for the config directory tries to set the permissions for the installation directory too early and results in an puppet error. This should fix the issue.

<!--
Thank you for contributing to this project!

- Please check that here is no existing issue or PR that addresses your problem.

-->
