### PR TITLE
Added support for distributed deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,24 @@ include ::minio
 
 See [REFERENCE.md](REFERENCE.md) for the full reference.
 
+## Configuration
+
+In addition to standard [minio server environment variables][minio-environment-variables],
+there are the following ones:
+
+* `MINIO_OPTS` - used to specify additional command-line arguments for the minio server.
+  Example: `"--quiet --anonymous"` (with quotes)
+
+* `MINIO_DEPLOYMENT_DEFINITION` - used to specify custom deployment definition.
+  Required for erasure coding and distributed mode. Not required if used with
+  a single storage root.
+  Examples:
+
+  * `/var/minio{1...4}` - for erasure coding
+  * `https://server{1...4}/var/minio{1...4} https://server{4...8}/var/minio{1...4}` - for distributed deployments
+  * `/var/minio` - for standalone deployment without erasure coding. Will be the default value
+    if `storage_root` is `/var/minio` or `['/var/minio']`.
+
 ### Class: `minio`
 
 ```puppet
@@ -52,13 +70,15 @@ class { 'minio':
     checksum_type                 => 'sha256',
     configuration_directory       => '/etc/minio',
     installation_directory        => '/opt/minio',
-    storage_root                  => '/var/minio',
+    storage_root                  => '/var/minio', # Could also be an array
     listen_ip                     => '127.0.0.1',
     listen_port                   => 9000,
     configuration                 => {
-        'MINIO_ACCESS_KEY'  => 'admin',
-        'MINIO_SECRET_KEY'  => 'password',
-        'MINIO_REGION_NAME' => 'us-east-1',
+        'MINIO_ACCESS_KEY'            => 'admin',
+        'MINIO_SECRET_KEY'            => 'password',
+        'MINIO_REGION_NAME'           => 'us-east-1',
+        'MINIO_OPTS'                  => '"--quiet --anonymous"',
+        'MINIO_DEPLOYMENT_DEFINITION' => 'https://example{1..4}.com/var/minio{1...4} https://example{5..8}.com/var/minio{1...4}'
     },
     manage_service                => true,
     service_template              => 'minio/systemd.erb',
@@ -103,13 +123,15 @@ class { 'minio::server':
     checksum_type              => 'sha256',
     configuration_directory    => '/etc/minio',
     installation_directory     => '/opt/minio',
-    storage_root               => '/var/minio',
+    storage_root               => '/var/minio', # Could also be an array
     listen_ip                  => '127.0.0.1',
     listen_port                => 9000,
     configuration              => {
-        'MINIO_ACCESS_KEY'  => 'admin',
-        'MINIO_SECRET_KEY'  => 'password',
-        'MINIO_REGION_NAME' => 'us-east-1',
+        'MINIO_ACCESS_KEY'            => 'admin',
+        'MINIO_SECRET_KEY'            => 'password',
+        'MINIO_REGION_NAME'           => 'us-east-1',
+        'MINIO_OPTS'                  => '"--quiet --anonymous"',
+        'MINIO_DEPLOYMENT_DEFINITION' => 'https://example{1..4}.com/var/minio{1...4} https://example{5..8}.com/var/minio{1...4}'
     },
     manage_service             => true,
     service_template           => 'minio/systemd.erb',
@@ -186,6 +208,7 @@ When submitting pull requests, please make sure that module documentation,
 test cases and syntax checks pass.
 
 [minio]: https://minio.io
+[minio-environment-variables]: https://docs.min.io/minio/baremetal/reference/minio-server/minio-server.html#minio-server-environment-variables
 [puppetlabs-stdlib]: https://github.com/puppetlabs/puppetlabs-stdlib
 [puppet-archive]: https://github.com/voxpupuli/puppet-archive
 [puppet-certs]: https://github.com/broadinstitute/puppet-certs

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -207,9 +207,9 @@ Target directory to hold the minio installation. Default: `/opt/minio`
 
 ##### <a name="storage_root"></a>`storage_root`
 
-Data type: `Stdlib::Absolutepath`
+Data type: `Variant[Stdlib::Absolutepath, Array[Stdlib::Absolutepath]]`
 
-Directory where minio will keep all data. Default: `/var/minio`
+Directory or directories where minio will keep all data. Default: `/var/minio`
 
 ##### <a name="listen_ip"></a>`listen_ip`
 
@@ -645,7 +645,7 @@ class { 'minio::server':
     checksum_type                  => 'sha256',
     configuration_directory        => '/etc/minio',
     installation_directory         => '/opt/minio',
-    storage_root                   => '/var/minio',
+    storage_root                   => '/var/minio', # Could also be an array
     listen_ip                      => '127.0.0.1',
     listen_port                    => 9000,
     configuration                  => {
@@ -832,9 +832,9 @@ Default value: `$minio::installation_directory`
 
 ##### <a name="storage_root"></a>`storage_root`
 
-Data type: `Stdlib::Absolutepath`
+Data type: `Variant[Stdlib::Absolutepath, Array[Stdlib::Absolutepath]]`
 
-Directory where minio will keep all data. Default: `/var/minio`
+Directory or directories where minio will keep all data. Default: `/var/minio`
 
 Default value: `$minio::storage_root`
 
@@ -1124,9 +1124,9 @@ Default value: `$minio::server::installation_directory`
 
 ##### <a name="storage_root"></a>`storage_root`
 
-Data type: `Stdlib::Absolutepath`
+Data type: `Variant[Stdlib::Absolutepath, Array[Stdlib::Absolutepath]]`
 
-Directory where minio will keep all data./minio`
+Directory or directories where minio will keep all data.
 
 Default value: `$minio::server::storage_root`
 
@@ -1275,9 +1275,9 @@ Default value: `$minio::server::installation_directory`
 
 ##### <a name="storage_root"></a>`storage_root`
 
-Data type: `Stdlib::Absolutepath`
+Data type: `Variant[Stdlib::Absolutepath, Array[Stdlib::Absolutepath]]`
 
-Directory where minio will keep all data./minio`
+Directory or directories where minio will keep all data.
 
 Default value: `$minio::server::storage_root`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -76,8 +76,8 @@
 #   Directory holding Minio configuration file. Default: `/etc/minio`
 # @param [Stdlib::Absolutepath] installation_directory
 #   Target directory to hold the minio installation. Default: `/opt/minio`
-# @param [Stdlib::Absolutepath] storage_root
-#   Directory where minio will keep all data. Default: `/var/minio`
+# @param [Variant[Stdlib::Absolutepath, Array[Stdlib::Absolutepath]]] storage_root
+#   Directory or directories where minio will keep all data. Default: `/var/minio`
 # @param [Stdlib::IP::Address] listen_ip
 #   IP address on which Minio should listen to requests.
 # @param [Stdlib::Port] listen_port
@@ -156,7 +156,7 @@ class minio (
   String $checksum_type,
   Stdlib::Absolutepath $configuration_directory,
   Stdlib::Absolutepath $installation_directory,
-  Stdlib::Absolutepath $storage_root,
+  Variant[Stdlib::Absolutepath, Array[Stdlib::Absolutepath]] $storage_root,
   Stdlib::IP::Address $listen_ip,
   Stdlib::Port $listen_port,
 

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -13,7 +13,7 @@
 #      checksum_type                  => 'sha256',
 #      configuration_directory        => '/etc/minio',
 #      installation_directory         => '/opt/minio',
-#      storage_root                   => '/var/minio',
+#      storage_root                   => '/var/minio', # Could also be an array
 #      listen_ip                      => '127.0.0.1',
 #      listen_port                    => 9000,
 #      configuration                  => {
@@ -73,8 +73,8 @@
 #   Directory holding Minio configuration file. Default: `/etc/minio`
 # @param [Stdlib::Absolutepath] installation_directory
 #   Target directory to hold the minio installation. Default: `/opt/minio`
-# @param [Stdlib::Absolutepath] storage_root
-#   Directory where minio will keep all data. Default: `/var/minio`
+# @param [Variant[Stdlib::Absolutepath, Array[Stdlib::Absolutepath]]] storage_root
+#   Directory or directories where minio will keep all data. Default: `/var/minio`
 # @param [Stdlib::IP::Address] listen_ip
 #   IP address on which Minio should listen to requests.
 # @param [Stdlib::Port] listen_port
@@ -132,7 +132,7 @@ class minio::server (
   String $checksum_type = $minio::checksum_type,
   Stdlib::Absolutepath $configuration_directory = $minio::configuration_directory,
   Stdlib::Absolutepath $installation_directory = $minio::installation_directory,
-  Stdlib::Absolutepath $storage_root = $minio::storage_root,
+  Variant[Stdlib::Absolutepath, Array[Stdlib::Absolutepath]] $storage_root = $minio::storage_root,
   Stdlib::IP::Address $listen_ip = $minio::listen_ip,
   Stdlib::Port $listen_port = $minio::listen_port,
 

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -24,8 +24,8 @@
 #   Directory holding Minio configuration file./minio`
 # @param [Stdlib::Absolutepath] installation_directory
 #   Target directory to hold the minio installation./minio`
-# @param [Stdlib::Absolutepath] storage_root
-#   Directory where minio will keep all data./minio`
+# @param [Variant[Stdlib::Absolutepath, Array[Stdlib::Absolutepath]]] storage_root
+#   Directory or directories where minio will keep all data.
 # @param [Hash[String[1], Variant[String, Integer]]] configuration
 #   Hash with environment settings for Minio.
 # @param [Optional[Stdlib::Absolutepath]] custom_configuration_file_path
@@ -40,22 +40,27 @@
 # Copyright 2017-2021 Daniel S. Reichenbach <https://kogitoapp.com>
 #
 class minio::server::config (
-  Hash[String[1], Variant[String, Integer]]          $configuration                  = $minio::server::configuration,
-  String                                             $owner                          = $minio::server::owner,
-  String                                             $group                          = $minio::server::group,
-  Stdlib::Absolutepath                               $configuration_directory        = $minio::server::configuration_directory,
-  Stdlib::Absolutepath                               $installation_directory         = $minio::server::installation_directory,
-  Stdlib::Absolutepath                               $storage_root                   = $minio::server::storage_root,
-  Optional[Stdlib::Absolutepath]                     $custom_configuration_file_path = $minio::server::custom_configuration_file_path,
+  Hash[String[1], Variant[String, Integer]] $configuration = $minio::server::configuration,
+  String $owner = $minio::server::owner,
+  String $group = $minio::server::group,
+  Stdlib::Absolutepath $configuration_directory = $minio::server::configuration_directory,
+  Stdlib::Absolutepath $installation_directory = $minio::server::installation_directory,
+  Variant[Stdlib::Absolutepath, Array[Stdlib::Absolutepath]] $storage_root = $minio::server::storage_root,
+  Optional[Stdlib::Absolutepath] $custom_configuration_file_path = $minio::server::custom_configuration_file_path,
   ) {
+
+  $storage = [$storage_root].flatten()
+  if ($storage.length() > 1 and !has_key($configuration, 'MINIO_DEPLOYMENT_DEFINITION')) {
+    fail('Please provide a value for the MINIO_DEPLOYMENT_DEFINITION in configuration to run distributed or erasure-coded deployment.')
+  }
 
   $configuration_file_path = pick($custom_configuration_file_path, "${configuration_directory}/config")
 
-
   $default_configuration = {
-    'MINIO_ROOT_USER'     => 'admin',
-    'MINIO_ROOT_PASSWORD' => 'password',
-    'MINIO_REGION_NAME'   => 'us-east-1',
+    'MINIO_ROOT_USER'             => 'admin',
+    'MINIO_ROOT_PASSWORD'         => 'password',
+    'MINIO_REGION_NAME'           => 'us-east-1',
+    'MINIO_DEPLOYMENT_DEFINITION' => $storage[0],
   }
 
   $resulting_configuration = deep_merge($default_configuration, $configuration)

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -2,146 +2,148 @@
 
 require 'spec_helper_acceptance'
 
-describe 'with default parameters ', if: ['debian', 'redhat', 'ubuntu'].include?(os[:family]) do
-  pp = <<-PUPPETCODE
-  class { 'minio': }
-PUPPETCODE
+describe 'minio', if: ['debian', 'redhat', 'ubuntu'].include?(os[:family]) do
+  describe 'with default parameters ' do
+    pp = <<-PUPPETCODE
+      class { 'minio': }
+    PUPPETCODE
 
-  it 'applies idempotently' do
-    idempotent_apply(pp)
+    it 'applies idempotently' do
+      idempotent_apply(pp)
+    end
+
+    describe group('minio') do
+      it { is_expected.to exist }
+    end
+
+    describe user('minio') do
+      it { is_expected.to exist }
+    end
+
+    describe file('/opt/minio') do
+      it { is_expected.to be_directory }
+    end
+
+    describe file('/etc/minio') do
+      it { is_expected.to be_directory }
+    end
+
+    describe file('/etc/minio/config') do
+      it { is_expected.to be_file }
+    end
+
+    describe file('/opt/minio/minio') do
+      it { is_expected.to be_file }
+    end
+
+    describe file('/var/minio') do
+      it { is_expected.to be_directory }
+    end
+
+    describe service('minio') do
+      it { is_expected.to be_enabled }
+      it { is_expected.to be_running.under('systemd') }
+    end
+
+    describe process('minio') do
+      its(:user) { is_expected.to eq 'minio' }
+      its(:args) { is_expected.to match 'server --certs-dir /etc/minio/certs --address 127.0.0.1:9000 /var/minio' }
+    end
+
+    describe port(9000) do
+      it { is_expected.to be_listening }
+    end
+
+    describe file('/usr/local/bin/minio-client') do
+      it {
+        is_expected.to be_file
+        is_expected.to be_mode 755
+        is_expected.to be_owned_by 'root'
+        is_expected.to be_grouped_into 'root'
+      }
+    end
+
+    describe file('/root/.minioclient') do
+      it {
+        is_expected.to be_symlink
+        is_expected.to be_linked_to '/usr/local/bin/minio-client'
+        is_expected.to be_owned_by 'root'
+        is_expected.to be_grouped_into 'root'
+      }
+    end
   end
 
-  describe group('minio') do
-    it { is_expected.to exist }
+  describe 'with multiple storage roots', if: ['debian', 'redhat', 'ubuntu'].include?(os[:family]) do
+    pp = <<-PUPPETCODE
+      class { 'minio':
+        storage_root  => [
+          '/var/minio1',
+          '/var/minio2',
+          '/var/minio3',
+          '/var/minio4',
+        ],
+        configuration => {
+          'MINIO_DEPLOYMENT_DEFINITION' => '/var/minio{1...4}',
+        },
+      }
+    PUPPETCODE
+
+    it 'applies idempotently' do
+      idempotent_apply(pp)
+    end
+
+    describe file('/var/minio1') do
+      it { is_expected.to be_directory }
+    end
+
+    describe file('/var/minio2') do
+      it { is_expected.to be_directory }
+    end
+
+    describe file('/var/minio3') do
+      it { is_expected.to be_directory }
+    end
+
+    describe file('/var/minio4') do
+      it { is_expected.to be_directory }
+    end
+
+    describe service('minio') do
+      it {
+        is_expected.to be_enabled
+        is_expected.to be_running.under('systemd')
+      }
+    end
+
+    describe process('minio') do
+      its(:user) { is_expected.to eq 'minio' }
+      its(:args) { is_expected.to match 'server --certs-dir /etc/minio/certs --address 127.0.0.1:9000 /var/minio{1...4}' }
+    end
   end
 
-  describe user('minio') do
-    it { is_expected.to exist }
-  end
+  describe 'with extra commandline options', if: ['debian', 'redhat', 'ubuntu'].include?(os[:family]) do
+    pp = <<-PUPPETCODE
+      class { 'minio':
+        configuration => {
+          'MINIO_OPTS' => '"--quiet --anonymous"',
+        },
+      }
+    PUPPETCODE
 
-  describe file('/opt/minio') do
-    it { is_expected.to be_directory }
-  end
+    it 'applies idempotently' do
+      idempotent_apply(pp)
+    end
 
-  describe file('/etc/minio') do
-    it { is_expected.to be_directory }
-  end
+    describe service('minio') do
+      it {
+        is_expected.to be_enabled
+        is_expected.to be_running.under('systemd')
+      }
+    end
 
-  describe file('/etc/minio/config') do
-    it { is_expected.to be_file }
-  end
-
-  describe file('/opt/minio/minio') do
-    it { is_expected.to be_file }
-  end
-
-  describe file('/var/minio') do
-    it { is_expected.to be_directory }
-  end
-
-  describe service('minio') do
-    it { is_expected.to be_enabled }
-    it { is_expected.to be_running.under('systemd') }
-  end
-
-  describe process('minio') do
-    its(:user) { should eq 'minio' }
-    its(:args) { should match 'server --certs-dir /etc/minio/certs --address 127.0.0.1:9000 /var/minio' }
-  end
-
-  describe port(9000) do
-    it { is_expected.to be_listening }
-  end
-
-  describe file('/usr/local/bin/minio-client') do
-    it {
-      is_expected.to be_file
-      is_expected.to be_mode 755
-      is_expected.to be_owned_by 'root'
-      is_expected.to be_grouped_into 'root'
-    }
-  end
-
-  describe file('/root/.minioclient') do
-    it {
-      is_expected.to be_symlink
-      is_expected.to be_linked_to '/usr/local/bin/minio-client'
-      is_expected.to be_owned_by 'root'
-      is_expected.to be_grouped_into 'root'
-    }
-  end
-end
-
-describe 'with multiple storage roots', if: ['debian', 'redhat', 'ubuntu'].include?(os[:family]) do
-  pp = <<-PUPPETCODE
-  class { 'minio':
-    storage_root  => [
-      '/var/minio1',
-      '/var/minio2',
-      '/var/minio3',
-      '/var/minio4',
-    ],
-    configuration => {
-      'MINIO_DEPLOYMENT_DEFINITION' => '/var/minio{1...4}',
-    },
-  }
-PUPPETCODE
-
-  it 'applies idempotently' do
-    idempotent_apply(pp)
-  end
-
-  describe file('/var/minio1') do
-    it { is_expected.to be_directory }
-  end
-
-  describe file('/var/minio2') do
-    it { is_expected.to be_directory }
-  end
-
-  describe file('/var/minio3') do
-    it { is_expected.to be_directory }
-  end
-
-  describe file('/var/minio4') do
-    it { is_expected.to be_directory }
-  end
-
-  describe service('minio') do
-    it {
-      is_expected.to be_enabled
-      is_expected.to be_running.under('systemd')
-    }
-  end
-
-  describe process('minio') do
-    its(:user) { should eq 'minio' }
-    its(:args) { should match 'server --certs-dir /etc/minio/certs --address 127.0.0.1:9000 /var/minio{1...4}' }
-  end
-end
-
-describe 'with extra commandline options', if: ['debian', 'redhat', 'ubuntu'].include?(os[:family]) do
-  pp = <<-PUPPETCODE
-  class { 'minio':
-    configuration => {
-      'MINIO_OPTS' => '"--quiet --anonymous"',
-    },
-  }
-PUPPETCODE
-
-  it 'applies idempotently' do
-    idempotent_apply(pp)
-  end
-
-  describe service('minio') do
-    it {
-      is_expected.to be_enabled
-      is_expected.to be_running.under('systemd')
-    }
-  end
-
-  describe process('minio') do
-    its(:user) { should eq 'minio' }
-    its(:args) { should match 'server --quiet --anonymous --certs-dir /etc/minio/certs --address 127.0.0.1:9000 /var/minio' }
+    describe process('minio') do
+      its(:user) { is_expected.to eq 'minio' }
+      its(:args) { is_expected.to match 'server --quiet --anonymous --certs-dir /etc/minio/certs --address 127.0.0.1:9000 /var/minio' }
+    end
   end
 end

--- a/spec/classes/server/config_spec.rb
+++ b/spec/classes/server/config_spec.rb
@@ -40,7 +40,7 @@ describe 'minio::server::config' do
         end
 
         it {
-          is_expected.to compile.and_raise_error(/Please provide a value for the MINIO_DEPLOYMENT_DEFINITION in configuration to run distributed or erasure-coded deployment./)
+          is_expected.to compile.and_raise_error(%r{Please provide a value for the MINIO_DEPLOYMENT_DEFINITION in configuration to run distributed or erasure-coded deployment.})
         }
       end
 
@@ -50,7 +50,7 @@ describe 'minio::server::config' do
             storage_root: ['/var/minio1', '/var/minio2', '/var/minio3', '/var/minio4'],
             configuration: {
               MINIO_DEPLOYMENT_DEFINITION: '/var/minio{1...4}',
-            }
+            },
           )
         end
 

--- a/spec/classes/server/config_spec.rb
+++ b/spec/classes/server/config_spec.rb
@@ -15,20 +15,49 @@ describe 'minio::server::config' do
         }"
       end
 
+      let(:params) do
+        {
+          configuration: {},
+          owner: 'minio',
+          group: 'minio',
+          configuration_directory: '/etc/minio',
+          installation_directory: '/opt/minio',
+          storage_root: '/var/minio',
+          custom_configuration_file_path: '/etc/default/minio',
+        }
+      end
+
       context 'with all defaults' do
-        let :params do
-          {
-            configuration: {},
-            owner: 'minio',
-            group: 'minio',
-            configuration_directory: '/etc/minio',
-            installation_directory: '/opt/minio',
-            storage_root: '/var/minio',
-            custom_configuration_file_path: '/etc/default/minio',
-          }
+        it {
+          is_expected.to compile
+          is_expected.to contain_file('/etc/default/minio')
+        }
+      end
+
+      context 'with multiple storage roots and no MINIO_DEPLOYMENT_DEFINITION' do
+        let(:params) do
+          super().merge(storage_root: ['/var/minio1', '/var/minio2'])
         end
 
-        it { is_expected.to contain_file('/etc/default/minio') }
+        it {
+          is_expected.to compile.and_raise_error(/Please provide a value for the MINIO_DEPLOYMENT_DEFINITION in configuration to run distributed or erasure-coded deployment./)
+        }
+      end
+
+      context 'with multiple storage roots and MINIO_DEPLOYMENT_DEFINITION' do
+        let(:params) do
+          super().merge(
+            storage_root: ['/var/minio1', '/var/minio2', '/var/minio3', '/var/minio4'],
+            configuration: {
+              MINIO_DEPLOYMENT_DEFINITION: '/var/minio{1...4}',
+            }
+          )
+        end
+
+        it {
+          is_expected.to compile
+          is_expected.to contain_file('/etc/default/minio')
+        }
       end
     end
   end

--- a/spec/classes/server/install_spec.rb
+++ b/spec/classes/server/install_spec.rb
@@ -26,38 +26,64 @@ describe 'minio::server::install', type: :class do
         }"
       end
 
+      let :params do
+        {
+          package_ensure: 'present',
+          base_url: 'https://dl.minio.io/server/minio/release',
+          version: 'RELEASE.2017-09-29T19-16-56Z',
+          checksum: 'b7707b11c64e04be87b4cf723cca5e776b7ed3737c0d6b16b8a3d72c8b183135',
+          checksum_type: 'sha256',
+          owner: 'minio',
+          group: 'minio',
+          configuration_directory: '/etc/minio',
+          installation_directory: '/opt/minio',
+          storage_root: '/var/minio',
+          listen_ip: '127.0.0.1',
+          listen_port: 9000,
+          manage_service: true,
+          service_template: 'minio/systemd.erb',
+          service_provider: 'systemd',
+          cert_directory: '/etc/minio/certs',
+          custom_configuration_file_path: '/etc/default/minio',
+        }
+      end
+
       context 'with all defaults' do
+        it {
+          is_expected.to compile
+
+          is_expected.to contain_archive__download('/opt/minio/minio')
+          is_expected.to contain_file('/etc/minio')
+          is_expected.to contain_file('/opt/minio')
+          is_expected.to contain_file('/opt/minio/minio')
+          is_expected.to contain_file('/var/minio')
+          is_expected.to contain_systemd__unit_file('minio.service')
+          is_expected.to contain_exec('permissions:/etc/minio')
+          is_expected.to contain_exec('permissions:/opt/minio')
+          is_expected.to contain_exec('permissions:/var/minio')
+        }
+      end
+
+      context 'with multiple storage roots' do
         let :params do
-          {
-            package_ensure: 'present',
-            base_url: 'https://dl.minio.io/server/minio/release',
-            version: 'RELEASE.2017-09-29T19-16-56Z',
-            checksum: 'b7707b11c64e04be87b4cf723cca5e776b7ed3737c0d6b16b8a3d72c8b183135',
-            checksum_type: 'sha256',
-            owner: 'minio',
-            group: 'minio',
-            configuration_directory: '/etc/minio',
-            installation_directory: '/opt/minio',
-            storage_root: '/var/minio',
-            listen_ip: '127.0.0.1',
-            listen_port: 9000,
-            manage_service: true,
-            service_template: 'minio/systemd.erb',
-            service_provider: 'systemd',
-            cert_directory: '/etc/minio/certs',
-            custom_configuration_file_path: '/etc/default/minio',
-          }
+          super().merge(storage_root: ['/var/minio1', '/var/minio2'])
         end
 
-        it { is_expected.to contain_archive__download('/opt/minio/minio') }
-        it { is_expected.to contain_file('/etc/minio') }
-        it { is_expected.to contain_file('/opt/minio') }
-        it { is_expected.to contain_file('/opt/minio/minio') }
-        it { is_expected.to contain_file('/var/minio') }
-        it { is_expected.to contain_systemd__unit_file('minio.service') }
-        it { is_expected.to contain_exec('permissions:/etc/minio') }
-        it { is_expected.to contain_exec('permissions:/opt/minio') }
-        it { is_expected.to contain_exec('permissions:/var/minio') }
+        it {
+          is_expected.to compile
+
+          is_expected.to contain_archive__download('/opt/minio/minio')
+          is_expected.to contain_file('/etc/minio')
+          is_expected.to contain_file('/opt/minio')
+          is_expected.to contain_file('/opt/minio/minio')
+          is_expected.to contain_file('/var/minio1')
+          is_expected.to contain_file('/var/minio2')
+          is_expected.to contain_systemd__unit_file('minio.service')
+          is_expected.to contain_exec('permissions:/etc/minio')
+          is_expected.to contain_exec('permissions:/opt/minio')
+          is_expected.to contain_exec('permissions:/var/minio1')
+          is_expected.to contain_exec('permissions:/var/minio2')
+        }
       end
     end
   end

--- a/templates/systemd.erb
+++ b/templates/systemd.erb
@@ -15,7 +15,7 @@ Group=<%= @group %>
 PermissionsStartOnly=true
 
 EnvironmentFile=<%= @configuration_file_path %>
-ExecStart=<%= @installation_directory %>/minio server $MINIO_OPTS --certs-dir <%= @cert_directory %> --address <%= @listen_ip %>:<%= @listen_port %> <%= @storage_root %>
+ExecStart=<%= @installation_directory %>/minio server $MINIO_OPTS --certs-dir <%= @cert_directory %> --address <%= @listen_ip %>:<%= @listen_port %> $MINIO_DEPLOYMENT_DEFINITION
 
 StandardOutput=journal
 StandardError=inherit


### PR DESCRIPTION
Added support for distributed deployments, updated specs, and docs. 

Changed `storage_root` to accept both single path (for backward compatibility) and an array of paths, so that the module could now be used for deployments with erasure coding.

In addition to standard [minio server environment variables](https://docs.min.io/minio/baremetal/reference/minio-server/minio-server.html#minio-server-environment-variables), there are two additional now, that support further configuration of the deployment:

* `MINIO_OPTS` - used to specify additional command-line arguments for the minio server.
  Example: `"--quiet --anonymous"` (with quotes)

* `MINIO_DEPLOYMENT_DEFINITION` - used to specify custom deployment definition.
  Required for erasure coding and distributed mode. Not required if used with
  a single storage root.
  Examples:

  * `/var/minio{1...4}` - for erasure coding
  * `https://server{1...4}/var/minio{1...4} https://server{4...8}/var/minio{1...4}` - for distributed deployments
  * `/var/minio` - for standalone deployment without erasure coding. Will be the default value
    if `storage_root` is `/var/minio` or `['/var/minio']`.

Should also fix #17 once merged.