### PR TITLE
Changed to 3.0.0 release of broadinstitute/certs

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -6,10 +6,8 @@ fixtures:
     archive: 'puppet/archive'
     systemd: 'camptocamp/systemd'
     stdlib: 'puppetlabs/stdlib'
+    certs: 'broadinstitute/certs'
   repositories:
     facts: 'https://github.com/puppetlabs/puppetlabs-facts.git'
     puppet_agent: 'https://github.com/puppetlabs/puppetlabs-puppet_agent.git'
     provision: 'https://github.com/puppetlabs/provision.git'
-    certs:
-      repo: 'https://github.com/broadinstitute/puppet-certs.git'
-      ref: '9d45057d0efa9ce2d1fcca2f27127b5e1d23f74a'

--- a/metadata.json
+++ b/metadata.json
@@ -22,7 +22,7 @@
     },
     {
         "name": "broadinstitute/certs",
-        "version_requirement": ">= 2.5.1 < 3"
+        "version_requirement": ">= 3.0.0 < 4"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Changed to a tagged version of `broadinstitute/certs` that now includes broadinstitute/puppet-certs#53 required by this module to function.