### PR TITLE
Changed to allow 3.x versions of camptocamp/systemd

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -18,7 +18,7 @@
     },
     {
       "name": "camptocamp/systemd",
-      "version_requirement": ">= 1.1.1 < 3.0.0"
+      "version_requirement": ">= 1.1.1 < 4.0.0"
     },
     {
         "name": "broadinstitute/certs",


### PR DESCRIPTION
Changed to allow 3.x versions of `camptocamp/systemd` as the module is already compatible with it.