### PR TITLE
Add additional types and providers

### DIFF
--- a/lib/puppet/provider/minio_bucket/minio_bucket.rb
+++ b/lib/puppet/provider/minio_bucket/minio_bucket.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'puppet/resource_api/simple_provider'
+require 'puppet_x/minio/client'
+
+DEFAUlT_TARGET_ALIAS ||= 'puppet'.freeze
+
+# Implementation for the minio_bucket type using the Resource API.
+class Puppet::Provider::MinioBucket::MinioBucket < Puppet::ResourceApi::SimpleProvider
+  def get(context)
+    context.debug('Returning list of minio buckets')
+    return [] unless PuppetX::Minio::Client.installed?
+
+    @instances = []
+    PuppetX::Minio::Client.execute("ls #{DEFAUlT_TARGET_ALIAS}").each do |json_bucket|
+      @instances << to_puppet_bucket(json_bucket)
+    end
+    @instances
+  end
+
+  def create(context, name, should)
+    context.notice("Creating '#{name}' with #{should.inspect}")
+    PuppetX::Minio::Client.execute("mb #{DEFAUlT_TARGET_ALIAS}/#{name}")
+  end
+
+  def update(context, name, should)
+    context.warning('`update` method not implemented for `minio_bucket` provider')
+  end
+
+  def delete(context, name)
+    context.notice("Deleting '#{name}'")
+    PuppetX::Minio::Client.execute("rb --force #{DEFAUlT_TARGET_ALIAS}/#{name}")
+  end
+
+  def to_puppet_bucket(json)
+    # Delete trailing slashes from bucket name
+    name = json['key'].chomp('/')
+
+    {
+      ensure: 'present',
+      name: name,
+    }
+  end
+end

--- a/lib/puppet/provider/minio_client_alias/minio_client_alias.rb
+++ b/lib/puppet/provider/minio_client_alias/minio_client_alias.rb
@@ -3,6 +3,7 @@
 require 'json'
 require 'puppet/resource_api/simple_provider'
 require 'puppet_x/minio/client'
+require 'puppet_x/minio/util'
 
 LEGACY_PATH_SUPPORT_MAP ||= {
   '': 'auto',
@@ -12,6 +13,8 @@ LEGACY_PATH_SUPPORT_MAP ||= {
 
 # Implementation for the minio_client_alias type using the Resource API.
 class Puppet::Provider::MinioClientAlias::MinioClientAlias < Puppet::ResourceApi::SimpleProvider
+  include PuppetX::Minio::Util
+
   def get(context)
     context.debug('Returning list of minio client aliases')
     return [] unless PuppetX::Minio::Client.installed?
@@ -79,13 +82,5 @@ class Puppet::Provider::MinioClientAlias::MinioClientAlias < Puppet::ResourceApi
       api_signature: json['api'],
       path_lookup_support: path_lookup_support,
     }
-  end
-
-  def unwrap_maybe_sensitive(param)
-    if param.is_a?(Puppet::Pops::Types::PSensitiveType::Sensitive)
-      return param.unwrap
-    end
-
-    param
   end
 end

--- a/lib/puppet/provider/minio_group/minio_group.rb
+++ b/lib/puppet/provider/minio_group/minio_group.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require 'puppet/resource_api/simple_provider'
+require 'puppet_x/minio/client'
+
+DEFAUlT_TARGET_ALIAS ||= 'puppet'.freeze
+GROUP_STATUS_MAP ||= {
+  'enabled': true,
+  'disabled': false,
+}.freeze
+
+# Implementation for the minio_group type using the Resource API.
+class Puppet::Provider::MinioGroup::MinioGroup < Puppet::ResourceApi::SimpleProvider
+  def get(context)
+    context.debug('Returning list of minio groups')
+    return [] unless PuppetX::Minio::Client.installed?
+
+    # `mcli admin group list` returns an array
+    json_groups = PuppetX::Minio::Client.execute("admin group list #{DEFAUlT_TARGET_ALIAS}").first
+    return [] unless json_groups.key?('groups')
+
+    @instances = []
+    json_groups['groups'].each do |group|
+      # `mcli admin group info` returns an array
+      json_group_info = PuppetX::Minio::Client.execute("admin group info #{DEFAUlT_TARGET_ALIAS} #{group}").first
+      @instances << to_puppet_group(json_group_info)
+    end
+    @instances
+  end
+
+  def create(context, name, should)
+    context.notice("Creating '#{name}' with #{should.inspect}")
+
+    operations = []
+    operations << "admin group add #{DEFAUlT_TARGET_ALIAS} #{name} #{should[:members].join(' ')}"
+
+    operations << "admin group disable #{DEFAUlT_TARGET_ALIAS} #{name}" unless should[:enabled]
+    operations << "admin policy set #{DEFAUlT_TARGET_ALIAS} #{should[:policies].join(',')} group=#{name}" unless should[:policies].nil?
+
+    operations.each do |op|
+      PuppetX::Minio::Client.execute(op)
+    end
+  end
+
+  def update(context, name, should)
+    context.notice("Updating '#{name}' with #{should.inspect}")
+
+    # TODO: Do a proper update instead of recreating the group
+    delete(context, name)
+    create(context, name, should)
+  end
+
+  def delete(context, name)
+    context.notice("Deleting '#{name}'")
+
+    members = PuppetX::Minio::Client.execute("admin group info #{DEFAUlT_TARGET_ALIAS} #{name}").first['members']
+    operations = []
+
+    operations << "admin group remove #{DEFAUlT_TARGET_ALIAS} #{name} #{members.join(' ')}"
+    operations << "admin group remove #{DEFAUlT_TARGET_ALIAS} #{name}"
+
+    operations.each do |op|
+      PuppetX::Minio::Client.execute(op)
+    end
+  end
+
+  def to_puppet_group(json)
+    policies = if json['groupPolicy'].nil? then nil else json['groupPolicy'].split(',') end
+
+    {
+      ensure: 'present',
+      name: json['groupName'],
+      members: json['members'] || [],
+      policies: policies,
+      enabled:  GROUP_STATUS_MAP[json['groupStatus'].to_sym],
+    }
+  end
+end

--- a/lib/puppet/provider/minio_policy/minio_policy.rb
+++ b/lib/puppet/provider/minio_policy/minio_policy.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require 'json'
+require 'tempfile'
+
+require 'puppet/resource_api/simple_provider'
+require 'puppet_x/minio/client'
+
+DEFAUlT_TARGET_ALIAS ||= 'puppet'.freeze
+DEFAULT_POLICY_VERSION ||= '2012-10-17'.freeze
+
+# Implementation for the minio_policy type using the Resource API.
+class Puppet::Provider::MinioPolicy::MinioPolicy < Puppet::ResourceApi::SimpleProvider
+  def get(context)
+    context.debug('Returning list of minio policies')
+    return [] unless PuppetX::Minio::Client.installed?
+
+    json_policies = PuppetX::Minio::Client.execute("admin policy list #{DEFAUlT_TARGET_ALIAS}")
+    return [] if json_policies.empty?
+
+    @instances = []
+    json_policies.each do |policy|
+      # `mcli admin policy info` returns an array
+      json_policy_info = PuppetX::Minio::Client.execute("admin policy info #{DEFAUlT_TARGET_ALIAS} #{policy['policy']}").first
+      @instances << to_puppet_policy(json_policy_info)
+    end
+    @instances
+  end
+
+  def create(context, name, should)
+    context.notice("Creating '#{name}' with #{should.inspect}")
+
+    f = Tempfile.new(["#{name}-policy", '.json'])
+    begin
+      json_policy = Hash[:Version => DEFAULT_POLICY_VERSION, :Statement => should[:statement]].to_json
+
+      f.write(json_policy)
+      f.rewind
+
+      PuppetX::Minio::Client.execute("admin policy add #{DEFAUlT_TARGET_ALIAS} #{name} #{f.path}")
+    ensure
+      f.close
+      f.unlink
+    end
+  end
+
+  def update(context, name, should)
+    context.notice("Updating '#{name}' with #{should.inspect}")
+
+    # There's currently no way to update an existing policy via the client,
+    # so delete and recreate the policy
+    delete(context, name)
+    create(context, name, should)
+  end
+
+  def delete(context, name)
+    context.notice("Deleting '#{name}'")
+    PuppetX::Minio::Client.execute("admin policy remove #{DEFAUlT_TARGET_ALIAS} #{name}")
+  end
+
+  def to_puppet_policy(json)
+    statements = []
+    json['policyJSON']['Statement'].each do |s|
+      statements << sanitize_statement(s)
+    end
+
+    {
+      ensure: 'present',
+      name: json['policy'],
+      version: json['policyJSON']['Version'],
+      statement: statements,
+    }
+  end
+
+  def sanitize_statement(statement)
+    statement.transform_keys!(&:capitalize)
+
+    [:Action, :Resource].each do |k|
+      statement[k].sort! unless statement[k].nil?
+    end
+
+    statement
+  end
+
+  def canonicalize(_context, resources)
+    resources.each do |r|
+      unless r[:statement].nil?
+        r[:statement].each do |s|
+          s = sanitize_statement(s)
+        end
+      end
+    end
+  end
+end

--- a/lib/puppet/provider/minio_user/minio_user.rb
+++ b/lib/puppet/provider/minio_user/minio_user.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require 'puppet/resource_api/simple_provider'
+require 'puppet_x/minio/client'
+require 'puppet_x/minio/util'
+
+DEFAUlT_TARGET_ALIAS ||= 'puppet'.freeze
+
+# Implementation for the minio_user type using the Resource API.
+class Puppet::Provider::MinioUser::MinioUser < Puppet::ResourceApi::SimpleProvider
+  include PuppetX::Minio::Util
+
+  def get(context)
+    context.debug('Returning list of minio users')
+    return [] unless PuppetX::Minio::Client.installed?
+
+    @instances = []
+    PuppetX::Minio::Client.execute("admin user list #{DEFAUlT_TARGET_ALIAS}").each do |json_user|
+      # `mcli admin user info` returns an array
+      json_user_info = PuppetX::Minio::Client.execute("admin user info #{DEFAUlT_TARGET_ALIAS} #{json_user['accessKey']}").first
+      @instances << to_puppet_user(json_user_info)
+    end
+    @instances
+  end
+
+  def create(context, name, should)
+    context.notice("Creating '#{name}' with #{should.inspect}")
+
+    operations = []
+    operations << ["admin user add #{DEFAUlT_TARGET_ALIAS} #{should[:access_key]} #{unwrap_maybe_sensitive(should[:secret_key])}", sensitive: true]
+    operations << ["admin policy set #{DEFAUlT_TARGET_ALIAS} #{should[:policies].join(' ')} user=#{name}"] unless should[:policies].nil?
+
+    operations.each do |op|
+      PuppetX::Minio::Client.execute(*op)
+    end
+  end
+
+  def update(context, name, should)
+    context.notice("Updating '#{name}' with #{should.inspect}")
+
+    operations = []
+    operations << "admin policy set #{DEFAUlT_TARGET_ALIAS} #{should[:policies].join(' ')} user=#{name}" unless should[:policies].nil?
+
+    operations.each do |op|
+      PuppetX::Minio::Client.execute(op)
+    end
+  end
+
+  def delete(context, name)
+    context.notice("Deleting '#{name}'")
+    PuppetX::Minio::Client.execute("admin user remove #{DEFAUlT_TARGET_ALIAS} #{name}")
+  end
+
+  def insync?(context, _name, property_name, is_hash, should_hash)
+    context.debug("Checking whether #{property_name} is out of sync")
+    case property_name
+    when :secret_key
+      # Let Puppet believe that the resource doesn't need updating,
+      # since we can't check a user's secret key
+      true
+    end
+  end
+
+  def to_puppet_user(json)
+    policies = if json['policyName'].nil? then nil else json['policyName'].split(',') end
+
+    {
+      ensure: 'present',
+      access_key: json['accessKey'],
+      policies: policies,
+      member_of: json['memberOf'] || [],
+    }
+  end
+end

--- a/lib/puppet/type/minio_bucket.rb
+++ b/lib/puppet/type/minio_bucket.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'puppet/resource_api'
+
+Puppet::ResourceApi.register_type(
+  name: 'minio_bucket',
+  docs: <<-EOS,
+@summary Manages local MinIO S3 buckets
+@example
+  minio_bucket { 'my-bucket':
+    ensure => 'present',
+  }
+
+**Autorequires**:
+* `File[/root/.minioclient]`
+* `Minio_client_alias[puppet]`
+EOS
+  features: [],
+  attributes: {
+    ensure: {
+      type:    'Enum[present, absent]',
+      desc:    'Whether this resource should be present or absent on the target system.',
+      default: 'present',
+    },
+    name: {
+      type:      'String',
+      desc:      'The name of the resource you want to manage.',
+      behaviour: :namevar,
+    },
+  },
+)

--- a/lib/puppet/type/minio_group.rb
+++ b/lib/puppet/type/minio_group.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'puppet/resource_api'
+
+Puppet::ResourceApi.register_type(
+  name: 'minio_group',
+  docs: <<-EOS,
+@summary Manages local MinIO groups
+@example
+  minio_group { 'admins':
+    ensure   => 'present',
+    members  => ['userOne', 'userTwo'],
+    policies => ['consoleAdmin'],
+  }
+@example
+  minio_group { 'my-group':
+    ensure   => 'present',
+    members  => ['userThree', 'userFour'],
+    policies => ['custom-policy'],
+  }
+
+**Autorequires**:
+* `File[/root/.minioclient]`
+* `Minio_client_alias[puppet]`
+EOS
+  features: [],
+  attributes: {
+    ensure: {
+      type:    'Enum[present, absent]',
+      desc:    'Whether this resource should be present or absent on the target system.',
+      default: 'present',
+    },
+    name: {
+      type:      'String',
+      desc:      'The name of the resource you want to manage.',
+      behaviour: :namevar,
+    },
+    members: {
+      type: 'Array[String, 1]',
+      desc: 'List of users that should be part of this group.',
+    },
+    enabled: {
+      type: 'Optional[Boolean]',
+      desc: 'Set to false to disable this group. Defaults to true.',
+      default: true,
+    },
+    policies: {
+      type: 'Optional[Array[String]]',
+      desc: 'List of MinIO PBAC policies to set for this group.',
+    },
+  },
+)

--- a/lib/puppet/type/minio_policy.rb
+++ b/lib/puppet/type/minio_policy.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'puppet/resource_api'
+
+Puppet::ResourceApi.register_type(
+  name: 'minio_policy',
+  docs: <<-EOS,
+@summary Manages local MinIO policies
+@example
+  minio_policy { 'custom-policy':
+    ensure    => 'present',
+    statement => [
+      {
+        'Effect'   => 'Allow',
+        'Action'   => ['s3:ListBucket'],
+        'Resource' => ['arn:aws:s3:::my-bucket']
+      },
+      {
+        'Effect'   => 'Allow',
+        'Action'   => ['s3:GetObject', 's3:PutObject'],
+        'Resource' => ['arn:aws:s3:::my-bucket']
+      }
+    ],
+  }
+
+**Autorequires**:
+* `File[/root/.minioclient]`
+* `Minio_client_alias[puppet]`
+EOS
+  features: ['canonicalize'],
+  attributes: {
+    ensure: {
+      type:    'Enum[present, absent]',
+      desc:    'Whether this resource should be present or absent on the target system.',
+      default: 'present',
+    },
+    name: {
+      type:      'String',
+      desc:      'The name of the resource you want to manage.',
+      behaviour: :namevar,
+    },
+    version: {
+      type:      'String',
+      desc:      'Specifies the language syntax rules that are to be used to process a policy.',
+      behaviour: :read_only,
+    },
+    statement: {
+      type: 'Array[Hash]',
+      desc: 'List of statements describing the policy.',
+    }
+  },
+)

--- a/lib/puppet/type/minio_user.rb
+++ b/lib/puppet/type/minio_user.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'puppet/resource_api'
+
+Puppet::ResourceApi.register_type(
+  name: 'minio_user',
+  docs: <<-EOS,
+@summary Manages local MinIO users
+@example
+  minio_user { 'userOne':
+    ensure     => 'present',
+    secret_key => Sensitive('password'),
+    policies   => ['consoleAdmin', 'custom-policy'],
+  }
+
+**Autorequires**:
+* `File[/root/.minioclient]`
+* `Minio_client_alias[puppet]`
+EOS
+  features: ['custom_insync'],
+  attributes: {
+    ensure: {
+      type:    'Enum[present, absent]',
+      desc:    'Whether this resource should be present or absent on the target system.',
+      default: 'present',
+    },
+    access_key: {
+      type:      'String',
+      desc:      'The API access key',
+      behaviour: :namevar,
+    },
+    secret_key: {
+      type: 'Variant[Sensitive[String], String]',
+      desc: 'The API access secret',
+    },
+    policies: {
+      type:    'Optional[Array[String]]',
+      desc:    'List of MinIO PBAC policies to set for this user.',
+    },
+    member_of: {
+      type:      'Optional[Array[String]]',
+      desc:      'List of groups the user is a member of.',
+      behaviour: :read_only,
+    },
+  },
+)

--- a/lib/puppet_x/minio/util.rb
+++ b/lib/puppet_x/minio/util.rb
@@ -1,0 +1,13 @@
+module PuppetX
+  module Minio
+    module Util
+      def unwrap_maybe_sensitive(param)
+        if param.is_a?(Puppet::Pops::Types::PSensitiveType::Sensitive)
+          return param.unwrap
+        end
+
+        param
+      end
+    end
+  end
+end

--- a/spec/unit/puppet/provider/minio_bucket/minio_bucket_spec.rb
+++ b/spec/unit/puppet/provider/minio_bucket/minio_bucket_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+ensure_module_defined('Puppet::Provider::MinioBucket')
+require 'puppet/provider/minio_bucket/minio_bucket'
+
+RSpec.describe Puppet::Provider::MinioBucket::MinioBucket do
+  subject(:provider) { described_class.new }
+
+  let(:context) { instance_double('Puppet::ResourceApi::BaseContext', 'context') }
+
+  before :each do
+    allow(context).to receive(:debug)
+    allow(context).to receive(:notice)
+    allow(context).to receive(:warning)
+    allow(File).to receive(:exist?).and_return(true)
+    allow(File).to receive(:readlink).and_return('/usr/local/sbin/minio-client')
+    Puppet::Util::ExecutionStub.set do |_command, _options|
+      ''
+    end
+  end
+
+  describe '#get' do
+    it 'returns empty list when client is not installed' do
+      allow(File).to receive(:exist?).and_return(false)
+      expect(provider.get(context)).to eq []
+    end
+
+    it 'processes resources' do
+      Puppet::Util::ExecutionStub.set do |_command, _options|
+        <<-JSONSTRINGS
+        {"status": "success","type": "folder","lastModified": "1970-01-01T00:00:00.000+01:00","size": 0,"key": "bucket-one/","etag": "","url": "http://localhost:9200","versionOrdinal": 1}
+        {"status": "success","type": "folder","lastModified": "1970-01-01T00:00:00.000+01:00","size": 0,"key": "bucket-two/","etag": "","url": "http://localhost:9200","versionOrdinal": 1}
+        JSONSTRINGS
+      end
+
+      expect(context).to receive(:debug).with('Returning list of minio buckets')
+      expect(provider.get(context)).to eq [
+        {
+          name: 'bucket-one',
+          ensure: 'present',
+        },
+        {
+          name: 'bucket-two',
+          ensure: 'present',
+        },
+      ]
+    end
+  end
+
+  describe 'create(context, name, should)' do
+    it 'creates the resource' do
+      Puppet::Util::ExecutionStub.set do |command, _options|
+        expect(command).to eq '/usr/local/sbin/minio-client --json mb puppet/bucket-one'
+
+        ''
+      end
+
+      expect(context).to receive(:notice).with(%r{\ACreating 'bucket-one'})
+      provider.create(context, 'bucket-one', name: 'bucket-one', ensure: 'present')
+    end
+  end
+
+  describe 'update(context, name, should)' do
+    it 'updates the resource' do
+      expect(context).to receive(:warning).with('`update` method not implemented for `minio_bucket` provider')
+      provider.update(context, 'bucket-one', name: 'bucket-one-test', ensure: 'present')
+    end
+  end
+
+  describe 'delete(context, name)' do
+    it 'deletes the resource' do
+      Puppet::Util::ExecutionStub.set do |command, _options|
+        expect(command).to eq '/usr/local/sbin/minio-client --json rb --force puppet/bucket-one'
+
+        ''
+      end
+
+      expect(context).to receive(:notice).with(%r{\ADeleting 'bucket-one'})
+      provider.delete(context, 'bucket-one')
+    end
+  end
+end

--- a/spec/unit/puppet/provider/minio_group/minio_group_spec.rb
+++ b/spec/unit/puppet/provider/minio_group/minio_group_spec.rb
@@ -1,0 +1,174 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+ensure_module_defined('Puppet::Provider::MinioGroup')
+require 'puppet/provider/minio_group/minio_group'
+
+RSpec.describe Puppet::Provider::MinioGroup::MinioGroup do
+  subject(:provider) { described_class.new }
+
+  let(:context) { instance_double('Puppet::ResourceApi::BaseContext', 'context') }
+
+  before :each do
+    allow(context).to receive(:debug)
+    allow(context).to receive(:notice)
+    allow(File).to receive(:exist?).and_return(true)
+    allow(File).to receive(:readlink).and_return('/usr/local/sbin/minio-client')
+    Puppet::Util::ExecutionStub.set do |_command, _options|
+      ''
+    end
+  end
+
+  describe '#get' do
+    it 'returns empty list when client is not installed' do
+      allow(File).to receive(:exist?).and_return(false)
+      expect(provider.get(context)).to eq []
+    end
+
+    it 'processes resources' do
+      Puppet::Util::ExecutionStub.set do |command, _options|
+        case command
+        when /list/
+          out = <<-JSONSTRINGS
+          {"status": "success","groups": ["test-one","test-two"]}
+          JSONSTRINGS
+        when /test-one/
+          out = <<-JSONSTRINGS
+          {"status": "success","groupName": "test-one","members": ["user-one","user-two"],"groupStatus": "enabled","groupPolicy": "test-policy"}
+          JSONSTRINGS
+        else
+          out = <<-JSONSTRINGS
+          {"status": "success","groupName": "test-two","members": ["user-three","user-four"],"groupStatus": "enabled","groupPolicy": "consoleAdmin"}
+          JSONSTRINGS
+        end
+
+        out
+      end
+
+      expect(context).to receive(:debug).with('Returning list of minio groups')
+      expect(provider.get(context)).to eq [
+        {
+          name: 'test-one',
+          ensure: 'present',
+          members: ['user-one', 'user-two'],
+          policies: ['test-policy'],
+          enabled: true,
+        },
+        {
+          name: 'test-two',
+          ensure: 'present',
+          members: ['user-three', 'user-four'],
+          policies: ['consoleAdmin'],
+          enabled: true,
+        },
+      ]
+    end
+  end
+
+  describe 'create(context, name, should)' do
+    it 'with defaults' do
+      Puppet::Util::ExecutionStub.set do |command, _options|
+        expect(command).to eq '/usr/local/sbin/minio-client --json admin group add puppet test-one user-one user-two'
+
+        ''
+      end
+      expect(context).to receive(:notice).with(%r{\ACreating 'test-one'})
+
+      provider.create(context, 'test-one',
+                      name: 'test-one',
+                      ensure: 'present',
+                      members: ['user-one', 'user-two'],
+                      enabled: true)
+    end
+
+    it 'with policies set' do
+      Puppet::Util::ExecutionStub.set do |command, _options|
+        case command
+        when /policy/
+          expected_command = '/usr/local/sbin/minio-client --json admin policy set puppet custom-policy-one,custom-policy-two group=test-one'
+        else
+          expected_command = '/usr/local/sbin/minio-client --json admin group add puppet test-one user-one user-two'
+        end
+        expect(command).to eq(expected_command)
+
+        ''
+      end
+      expect(context).to receive(:notice).with (%r{\ACreating 'test-one'})
+
+      provider.create(context, 'test-one',
+                      name: 'test-one',
+                      ensure: 'present',
+                      members: ['user-one', 'user-two'],
+                      policies: ['custom-policy-one', 'custom-policy-two'],
+                      enabled: true)
+    end
+
+    it 'with group disabled' do
+      Puppet::Util::ExecutionStub.set do |command, _options|
+        case command
+        when /disable/
+          expected_command = '/usr/local/sbin/minio-client --json admin group disable puppet test-one'
+        else
+          expected_command = '/usr/local/sbin/minio-client --json admin group add puppet test-one user-one user-two'
+        end
+        expect(command).to eq(expected_command)
+
+        ''
+      end
+      expect(context).to receive(:notice).with (%r{\ACreating 'test-one'})
+
+      provider.create(context, 'test-one',
+                      name: 'test-one',
+                      ensure: 'present',
+                      members: ['user-one', 'user-two'],
+                      enabled: false)
+
+    end
+  end
+
+  describe 'update(context, name, should)' do
+    it 'updates the resource' do
+      expect(context).to receive(:notice).with(%r{\AUpdating 'test-one'})
+
+      expect(subject).to receive(:delete).with(context, 'test-one')
+      expect(subject).to receive(:create).with(context, 'test-one',
+                                               name: 'test-one',
+                                               ensure: 'present',
+                                               members: ['user-one'],
+                                               enabled: false)
+
+      provider.update(context, 'test-one',
+                      name: 'test-one',
+                      ensure: 'present',
+                      members: ['user-one'],
+                      enabled: false)
+    end
+  end
+
+  describe 'delete(context, name)' do
+    it 'deletes the resource' do
+      Puppet::Util::ExecutionStub.set do |command, _options|
+        case command
+        when /info/
+          expected_command = '/usr/local/sbin/minio-client --json admin group info puppet test-one'
+          out = <<-JSONSTRING
+          {"status": "success","groupName": "test-one","members": ["user-one","user-two"],"groupStatus": "enabled","groupPolicy": "test-policy"}
+          JSONSTRING
+        when /user/
+          expected_command = '/usr/local/sbin/minio-client --json admin group remove puppet test-one user-one user-two'
+          out = ''
+        else
+          expected_command = '/usr/local/sbin/minio-client --json admin group remove puppet test-one'
+          out = ''
+        end
+
+        expect(command).to eq(expected_command)
+        out
+      end
+      expect(context).to receive(:notice).with(%r{\ADeleting 'test-one'})
+
+      provider.delete(context, 'test-one')
+    end
+  end
+end

--- a/spec/unit/puppet/provider/minio_policy/minio_policy_spec.rb
+++ b/spec/unit/puppet/provider/minio_policy/minio_policy_spec.rb
@@ -1,0 +1,144 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+ensure_module_defined('Puppet::Provider::MinioPolicy')
+require 'puppet/provider/minio_policy/minio_policy'
+
+RSpec.describe Puppet::Provider::MinioPolicy::MinioPolicy do
+  subject(:provider) { described_class.new }
+
+  let(:context) { instance_double('Puppet::ResourceApi::BaseContext', 'context') }
+
+  before :each do
+    allow(context).to receive(:debug)
+    allow(context).to receive(:notice)
+    allow(File).to receive(:exist?).and_return(true)
+    allow(File).to receive(:readlink).and_return('/usr/local/sbin/minio-client')
+    Puppet::Util::ExecutionStub.set do |_command, _options|
+      ''
+    end
+  end
+
+  describe '#get' do
+    it 'returns empty list when client is not installed' do
+      allow(File).to receive(:exist?).and_return(false)
+      expect(provider.get(context)).to eq []
+    end
+
+    it 'processes resources' do
+      Puppet::Util::ExecutionStub.set do |command, _options|
+        case command
+        when /list/
+          out = <<-JSONSTRINGS
+          {"status": "success","policy": "test-one","isGroup": false}
+          JSONSTRINGS
+        else
+          out = <<-JSONSTRINGS
+          {"status": "success","policy": "test-one","isGroup": false,"policyJSON": {"Version": "2012-10-17","Statement": [{"Effect": "Allow","Action": ["s3:ListBucket"],"Resource": ["arn:aws:s3:::test-one-bucket-*"]},{"Effect": "Allow","Action": ["s3:GetObject","s3:PutObject"],"Resource": ["arn:aws:s3:::test-one-*"]}]}}
+          JSONSTRINGS
+        end
+
+        out
+      end
+
+      expect(context).to receive(:debug).with('Returning list of minio policies')
+      expect(provider.get(context)).to eq [
+        {
+          name: 'test-one',
+          ensure: 'present',
+          version: '2012-10-17',
+          statement: [  # Using hash rockets, since Puppet returns strings as hash keys
+            {
+              'Effect'   => 'Allow',
+              'Action'   => ['s3:ListBucket'],
+              'Resource' => ['arn:aws:s3:::test-one-bucket-*'],
+            },
+            {
+              'Effect'   => 'Allow',
+              'Action'   => ['s3:GetObject','s3:PutObject'],
+              'Resource' => ['arn:aws:s3:::test-one-*'],
+            },
+          ],
+        },
+      ]
+    end
+  end
+
+  describe 'create(context, name, should)' do
+    it 'creates the resource' do
+      Puppet::Util::ExecutionStub.set do |command, _options|
+        expect(command).to include '/usr/local/sbin/minio-client --json admin policy add puppet test-one'
+
+        ''
+      end
+      expect(context).to receive(:notice).with(%r{\ACreating 'test-one'})
+
+      provider.create(context, 'test-one',
+                      name: 'test-one',
+                      ensure: 'present',
+                      statement: [
+                        {
+                          Effect: 'Allow',
+                          Action:['s3:ListBucket'],
+                          Resource: ['arn:aws:s3:::test-one-bucket-*'],
+                        }
+                      ])
+    end
+  end
+
+  describe 'update(context, name, should)' do
+    it 'updates the resource' do
+      expect(context).to receive(:notice).with(%r{\AUpdating 'test-one'})
+
+      expect(subject).to receive(:delete).with(context, 'test-one')
+      expect(subject).to receive(:create).with(context, 'test-one',
+                                               name: 'test-one',
+                                               ensure: 'present',
+                                               statement: [
+                                                 {
+                                                   Effect: 'Allow',
+                                                   Action:['s3:ListBucket'],
+                                                   Resource: ['arn:aws:s3:::test-one-bucket-*'],
+                                                 }
+                                               ])
+
+    provider.update(context, 'test-one',
+                    name: 'test-one',
+                    ensure: 'present',
+                    statement: [
+                      {
+                        Effect: 'Allow',
+                        Action:['s3:ListBucket'],
+                        Resource: ['arn:aws:s3:::test-one-bucket-*'],
+                      }
+                    ])
+    end
+  end
+
+  describe 'delete(context, name)' do
+    it 'deletes the resource' do
+      Puppet::Util::ExecutionStub.set do |command, _options|
+        expect(command).to eq '/usr/local/sbin/minio-client --json admin policy remove puppet test-one'
+
+        ''
+      end
+      expect(context).to receive(:notice).with(%r{\ADeleting 'test-one'})
+
+      provider.delete(context, 'test-one')
+    end
+  end
+
+  describe 'sanitize_statement(statement)' do
+    def self.test_sanitize_statement(desc, input)
+      expected = {:Effect => 'Allow', :Action => ['s3:GetObject', 's3:PutObject'], :Resource => ['arn:aws:s3:::test-one-bucket-*']}
+
+      it desc do
+        expect(provider.sanitize_statement(input)).to eq expected
+      end
+    end
+
+    test_sanitize_statement 'capitalizes keys', {'effect': 'Allow', 'action': ['s3:GetObject', 's3:PutObject'], 'resource': ['arn:aws:s3:::test-one-bucket-*']}
+    test_sanitize_statement 'sorts Action and Resource arrays', {'Effect': 'Allow', 'Action': ['s3:PutObject', 's3:GetObject'], 'Resource': ['arn:aws:s3:::test-one-bucket-*']}
+  end
+end

--- a/spec/unit/puppet/provider/minio_user/minio_user_spec.rb
+++ b/spec/unit/puppet/provider/minio_user/minio_user_spec.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+ensure_module_defined('Puppet::Provider::MinioUser')
+require 'puppet/provider/minio_user/minio_user'
+
+RSpec.describe Puppet::Provider::MinioUser::MinioUser do
+  subject(:provider) { described_class.new }
+
+  let(:context) { instance_double('Puppet::ResourceApi::BaseContext', 'context') }
+
+  before :each do
+    allow(context).to receive(:debug)
+    allow(context).to receive(:notice)
+    allow(File).to receive(:exist?).and_return(true)
+    allow(File).to receive(:readlink).and_return('/usr/local/sbin/minio-client')
+    Puppet::Util::ExecutionStub.set do |_command, _options|
+      ''
+    end
+  end
+
+  describe '#get' do
+    it 'returns empty list when client is not installed' do
+      allow(File).to receive(:exist?).and_return(false)
+      expect(provider.get(context)).to eq []
+    end
+
+    it 'processes resources' do
+      Puppet::Util::ExecutionStub.set do |command, _options|
+        case command
+        when /list/
+          out = <<-JSONSTRINGS
+          {"status": "success","accessKey": "user-one","userStatus": "enabled"}
+          {"status": "success","accessKey": "user-two","userStatus": "enabled"}
+          JSONSTRINGS
+        when /user-one/
+          out = <<-JSONSTRINGS
+          {"status": "success","accessKey": "user-one","userStatus": "enabled","memberOf": ["group-one"]}
+          JSONSTRINGS
+        else
+          out = <<-JSONSTRINGS
+          {"status": "success","accessKey": "user-two","policyName": "readonly,custom-policy","userStatus": "enabled"}
+          JSONSTRINGS
+        end
+
+        out
+      end
+
+      expect(context).to receive(:debug).with('Returning list of minio users')
+      expect(provider.get(context)).to eq [
+        {
+          access_key: 'user-one',
+          ensure: 'present',
+          policies: nil,
+          member_of: ['group-one'],
+        },
+        {
+          access_key: 'user-two',
+          ensure: 'present',
+          policies: ['readonly','custom-policy'],
+          member_of: [],
+        },
+      ]
+    end
+  end
+
+  describe 'create(context, name, should)' do
+    it 'with defaults' do
+      Puppet::Util::ExecutionStub.set do |command, _options|
+        expect(command).to eq '/usr/local/sbin/minio-client --json admin user add puppet user-one MySecretPass'
+
+        ''
+      end
+      expect(context).to receive(:notice).with(%r{\ACreating 'user-one'})
+
+      provider.create(context, 'user-one',
+                      ensure: 'present',
+                      access_key: 'user-one',
+                      secret_key: Puppet::Pops::Types::PSensitiveType::Sensitive.new('MySecretPass'))
+    end
+
+    it 'with policies' do
+      Puppet::Util::ExecutionStub.set do |command, _options|
+        case command
+        when /policy/
+          expected_command = '/usr/local/sbin/minio-client --json admin policy set puppet readonly custom-policy user=user-one'
+        else
+          expected_command = '/usr/local/sbin/minio-client --json admin user add puppet user-one MySecretPass'
+        end
+        expect(command).to eq expected_command
+
+        ''
+      end
+      expect(context).to receive(:notice).with(%r{\ACreating 'user-one'})
+
+      provider.create(context, 'user-one',
+                      ensure: 'present',
+                      access_key: 'user-one',
+                      secret_key: Puppet::Pops::Types::PSensitiveType::Sensitive.new('MySecretPass'),
+                      policies: ['readonly', 'custom-policy'])
+    end
+  end
+
+  describe 'update(context, name, should)' do
+    it 'updates the resource' do
+      Puppet::Util::ExecutionStub.set do |command, _options|
+        expect(command).to eq '/usr/local/sbin/minio-client --json admin policy set puppet consoleAdmin user=user-one'
+
+        ''
+      end
+      expect(context).to receive(:notice).with(%r{\AUpdating 'user-one'})
+
+      provider.update(context, 'user-one',
+                      ensure: 'present',
+                      access_key: 'user-one',
+                      policies: ['consoleAdmin'])
+    end
+  end
+
+  describe 'delete(context, name)' do
+    it 'deletes the resource' do
+      Puppet::Util::ExecutionStub.set do |command, _options|
+        expect(command).to eq '/usr/local/sbin/minio-client --json admin user remove puppet user-one'
+
+        ''
+      end
+      expect(context).to receive(:notice).with(%r{\ADeleting 'user-one'})
+
+      provider.delete(context, 'user-one')
+    end
+  end
+end

--- a/spec/unit/puppet/type/minio_bucket_spec.rb
+++ b/spec/unit/puppet/type/minio_bucket_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'puppet/type/minio_bucket'
+
+RSpec.describe 'the minio_bucket type' do
+  it 'loads' do
+    expect(Puppet::Type.type(:minio_bucket)).not_to be_nil
+  end
+end

--- a/spec/unit/puppet/type/minio_group_spec.rb
+++ b/spec/unit/puppet/type/minio_group_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'puppet/type/minio_group'
+
+RSpec.describe 'the minio_group type' do
+  it 'loads' do
+    expect(Puppet::Type.type(:minio_group)).not_to be_nil
+  end
+end

--- a/spec/unit/puppet/type/minio_policy_spec.rb
+++ b/spec/unit/puppet/type/minio_policy_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'puppet/type/minio_policy'
+
+RSpec.describe 'the minio_policy type' do
+  it 'loads' do
+    expect(Puppet::Type.type(:minio_policy)).not_to be_nil
+  end
+end

--- a/spec/unit/puppet/type/minio_user_spec.rb
+++ b/spec/unit/puppet/type/minio_user_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'puppet/type/minio_user'
+
+RSpec.describe 'the minio_user type' do
+  it 'loads' do
+    expect(Puppet::Type.type(:minio_user)).not_to be_nil
+  end
+end


### PR DESCRIPTION
This PR adds the following types and providers for managing local MinIO resources:
* `minio_user`
* `minio_group`
* `minio_bucket`
* `minio_policy`

These work for the most part; there are still some caveats:
* It's not possible to update the secret key of a user, since the CLI doesn't report the secret key when fetching users. 
* Assigning policies only works reliably when doing so via either `minio_user` or `minio_group`. Attempting to mix those two providers for policy assignment might result in assigned policies being overwritten.
* The `minio_group` provider processes updates by recreating the whole group to keeps things simple. A proper update would require removing and/or adding members via the CLI in a certain order.
* A client alias with the name `puppet` is hardcoded into the provider code, since the MinIO CLI needs an alias to retrieve and create MinIO resources. This alias would need to be created before running the providers.

I'm running the providers on a Debian 11 VM against the following MinIO versions:
```
$ sudo mcli admin info puppet
●  127.0.0.1:9000
   Uptime: 1 week 
   Version: 2021-11-03T03:36:36Z
   Network: 1/1 OK 

3.1 MiB Used, 7 Buckets, 1 Object

$ sudo mcli --version
mcli version RELEASE.2021-10-07T04-19-58Z

$ cat /etc/os-release 
PRETTY_NAME="Debian GNU/Linux 11 (bullseye)"
NAME="Debian GNU/Linux"
VERSION_ID="11"
VERSION="11 (bullseye)"
VERSION_CODENAME=bullseye
ID=debian
HOME_URL="https://www.debian.org/"
SUPPORT_URL="https://www.debian.org/support"
BUG_REPORT_URL="https://bugs.debian.org/"
```

I'm still working on my Ruby skills, feedback is always welcome :)